### PR TITLE
Updated ice_nc4.py

### DIFF
--- a/src/ice_nc4.py
+++ b/src/ice_nc4.py
@@ -53,12 +53,14 @@ if daily:
     for (year, month), files in grouped.items():
         days_in_month = monthrange(int(year), int(month))[1]
         available_days = [int(f[-5:-3]) for f in files]
-        if all(day in available_days for day in range(1, days_in_month + 1)):
+        included_list = [day in available_days for day in range(1, days_in_month + 1)]
+        if all(included_list):
             cmd = ["ncrcat", "-4", "--deflate", "4", *files, f"iceh_d.{year}-{month}.nc"]
             if verbose:
                 print(cmd)
             subprocess.check_call(cmd, stderr=subprocess.STDOUT)
         else:
-            raise Exception(f"Missing daily data for {year}-{month}. Available files: {files}")
+            day = included_list.index(False)+1
+            raise Exception(f"Missing daily data 'iceh.{year}-{month}-{day}'.")
 else:
     print("No daily data to process.")

--- a/src/ice_nc4.py
+++ b/src/ice_nc4.py
@@ -8,53 +8,57 @@
 
 # Should be run in the CICE history output directory
 
-import os, glob, re, subprocess, calendar
+import os, glob, re, subprocess, warnings
+from collections import defaultdict
+from calendar import monthrange
 
 # Expect that all files have prefix iceh
 
 # Check for end of string so as not to match nc4 files etc.
 # Rename to iceh_m and iceh_d so that they don't match.
-
 verbose = True
-re_monthly = re.compile("iceh.\d\d\d\d-\d\d.nc")
-re_daily = re.compile("iceh.\d\d\d\d-\d\d-\d\d.nc")
+re_monthly = re.compile(r"iceh\.\d{4}-\d{2}\.nc")
+re_daily = re.compile(r"iceh\.\d{4}-\d{2}-\d{2}\.nc")
+
 monthly = []
+daily = []
 for f in glob.glob('iceh.*.nc'):
-    m = re_monthly.match(f)
-    if m:
+    if re_monthly.match(f):
         monthly.append(f)
-        continue
-    m = re_daily.match(f)
-    if m:
-        continue
-    raise Exception("Unexpected file %s" % f)
+    elif re_daily.match(f):
+        daily.append(f)
+    else:
+        warnings.warn(f"Unexpected file '{f}'.")
 
-if not monthly:
-    print("No files to process")
+# Convert monthly data to netCDF4 format and compress
+if monthly:
+    for f in monthly:
+        cmd = ["nccopy", "-k3", "-d4", f, f"iceh_m{f[4:]}"]
+        if verbose:
+            print(cmd)
+        subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+else:
+    print("No monthly data to process.")
 
-monthly.sort()
-
-cal = calendar.Calendar()
-for f in monthly:
-    # Note that spaces are not allowed in subprocess arguments
-    cmd = ["nccopy", "-k3", "-d4", f, "iceh_m%s" % f[4:]]
-    if verbose:
-        print(cmd)
-    subprocess.check_call(cmd, stderr=subprocess.STDOUT)
-
-    year = int(f[5:9])
-    month = int(f[10:12])
-
-    cmd = ["ncrcat", "-4", "--deflate", "4"]
-    for date in cal.itermonthdates(year,month):
-        # Days of this month (assuming proleptic Gregorian)
-        # This returns days of preceding and following months
-        # to give complete weeks, so need to check actual month.
-        if date.month == month:
-            # strftime doesn't format years before 1000 properly
-            cmd.append("iceh.%4.4d-%2.2d-%2.2d.nc" %
-                       (date.year, date.month, date.day))
-    cmd.append("iceh_d%s" % f[4:])
-    if verbose:
-        print(cmd)
-    subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+# Combine separate daily data in the same netCDF4 file
+if daily:
+    daily.sort()
+    # Group files with same year and month
+    grouped = defaultdict(list)
+    for filename in daily:
+        year, month, _ = filename[5:-3].split("-")
+        grouped[(year, month)].append(filename)
+    
+    # Combine data if all days are present for each year-month group
+    for (year, month), files in grouped.items():
+        days_in_month = monthrange(int(year), int(month))[1]
+        available_days = [int(f[-5:-3]) for f in files]
+        if all(day in available_days for day in range(1, days_in_month + 1)):
+            cmd = ["ncrcat", "-4", "--deflate", "4", *files, f"iceh_d.{year}-{month}.nc"]
+            if verbose:
+                print(cmd)
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+        else:
+            raise Exception(f"Missing daily data for {year}-{month}. Available files: {files}")
+else:
+    print("No daily data to process.")

--- a/src/ice_nc4.py
+++ b/src/ice_nc4.py
@@ -2,13 +2,17 @@
 
 # Convert CICE history to netCDF4 and combine separate daily files
 # into a single monthly file.
+# This script assumes a proleptic Gregorian calendar.
 
 # Note that adding shuffle actually increases the size of the
 # monthly files.
 
 # Should be run in the CICE history output directory
 
-import os, glob, re, subprocess, warnings
+import glob
+import re
+import subprocess
+import warnings
 from collections import defaultdict
 from calendar import monthrange
 
@@ -51,7 +55,7 @@ if daily:
     
     # Combine data if all days are present for each year-month group
     for (year, month), files in grouped.items():
-        days_in_month = monthrange(int(year), int(month))[1]
+        days_in_month = monthrange(int(year), int(month))[1] # Assuming a proleptic Gregorian calendar
         available_days = [int(f[-5:-3]) for f in files]
         included_list = [day in available_days for day in range(1, days_in_month + 1)]
         if all(included_list):

--- a/src/ice_nc4.py
+++ b/src/ice_nc4.py
@@ -61,6 +61,6 @@ if daily:
             subprocess.check_call(cmd, stderr=subprocess.STDOUT)
         else:
             day = included_list.index(False)+1
-            raise Exception(f"Missing daily data 'iceh.{year}-{month}-{day}'.")
+            raise Exception(f"Missing daily data 'iceh.{year}-{month}-{day:02d}.nc'.")
 else:
     print("No daily data to process.")

--- a/src/ice_nc4.py
+++ b/src/ice_nc4.py
@@ -36,7 +36,7 @@ if monthly:
         cmd = ["nccopy", "-k3", "-d4", f, f"iceh_m{f[4:]}"]
         if verbose:
             print(cmd)
-        subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+        subprocess.run(cmd, check=True)
 else:
     print("No monthly data to process.")
 
@@ -58,7 +58,7 @@ if daily:
             cmd = ["ncrcat", "-4", "--deflate", "4", *files, f"iceh_d.{year}-{month}.nc"]
             if verbose:
                 print(cmd)
-            subprocess.check_call(cmd, stderr=subprocess.STDOUT)
+            subprocess.run(cmd, check=True)
         else:
             day = included_list.index(False)+1
             raise Exception(f"Missing daily data 'iceh.{year}-{month}-{day:02d}.nc'.")


### PR DESCRIPTION
Fixes #2.

## Overview of the changes

- [x] Monthly and daily data processed separately and independently, only if data exist.
- [x] Instead of raising an exception if it finds a file formatted in an unexpected way, it raises a warning and continue (if all the rest of the data is properly formatted and present, the conversions would still happen and the "unexpected" data is simply ignored)
- [x] Minor updates (f-strings, general syntax, etc.)
- [x] Switched `subprocess.check_call` with `subprocess.run(..., check=True)` for better error handling.
- [x] Removed the redirection of `stderr` to `stdout` (`stderr` will now be directed to `job.err` instead of `job.out`). 

## Regression tests

The scripts in these repo don't have unit-testing, nor regression tests.
However, I made a quick regression-test to compare the commands run by the "[old](https://github.com/ACCESS-NRI/access-cm2-drivers/blob/605d838e37ab0e452e4e72326ae7a384f9398576/src/ice_nc4.py)" and "[new](https://github.com/ACCESS-NRI/access-cm2-drivers/blob/4c2e057bc4a76b28f3ab838923fa7db6163dfae0/src/ice_nc4.py)" versions of `ice_nc4.py`.

### Tests structure
The tests are all in `/scratch/tm70/dm5220/test_access_cm2_drivers`.
In the folder there are two scripts: `ice_nc4_old.py` and `ice_nc4_new.py`, correspondent to the "old" and "new" versions of `ice_nc4.py`, respectively. In these files, all `subprocess.check_call` commands have been commented out, so that the commands wouldn't get actually run but only printed out.
Along with the `ice_nc4_*.py` files, there are multiple folders containing mocked-data (empty files) properly named to be used within the scripts. The list of the folders is:
- `both` --> contains both monthly (`iceh.YYYY-MM.nc`) and daily (`iceh.YYYY-MM-DD.nc`) data for April and May 1992
- `both_unexpected` --> contains the same files as `both`, with 2 additional "unexpected" files: `iceh.unexpected.nc` and `iceh.1992.04.05.nc`
- `both_missing` --> contains the same files as `both`, without 1 file: `iceh.1992-05-04.nc`
- `only_monthly` --> contains only the monthly data of `both`
- `only_daily` --> contains only the daily data of `both`

Each function test can be run with:
```
./script.py folder
```

### Test outcome
#### both
##### "old" and "new" versions
```
$ diff <(./ice_nc4_old.py both | sort) <(./ice_nc4_new.py both | sort)
```
doesn't throw any output.
This means that the same commands are run for both "old" and "new" versions (`sort` is used because the commands for the "old" and "new" versions are run in different order, so not sorting the `diff` would produce output harder to understand).
Note that the command order is irrelevant for the correctness of the whole routine.

#### both_unexpected
##### "old" version
```
$ ./ice_nc4_old.py both_unexpected
Traceback (most recent call last):
  File "./ice_nc4_old.py", line 31, in <module>
    raise Exception("Unexpected file %s" % f)
Exception: Unexpected file iceh.1992.04.05.nc
```
The "old" version simply fails

##### "new" version
```
$ ./ice_nc4_new.py both_unexpected
./ice_nc4_new.py:33: UserWarning: Unexpected file 'iceh.1992.04.05.nc'.
  warnings.warn(f"Unexpected file '{f}'.")
./ice_nc4_new.py:33: UserWarning: Unexpected file 'iceh.unexpected.nc'.
  warnings.warn(f"Unexpected file '{f}'.")
['nccopy', '-k3', '-d4', 'iceh.1992-05.nc', 'iceh_m.1992-05.nc']
['nccopy', '-k3', '-d4', 'iceh.1992-04.nc', 'iceh_m.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-04-01.nc', 'iceh.1992-04-02.nc', 'iceh.1992-04-03.nc', 'iceh.1992-04-04.nc', 'iceh.1992-04-05.nc', 'iceh.1992-04-06.nc', 'iceh.1992-04-07.nc', 'iceh.1992-04-08.nc', 'iceh.1992-04-09.nc', 'iceh.1992-04-10.nc', 'iceh.1992-04-11.nc', 'iceh.1992-04-12.nc', 'iceh.1992-04-13.nc', 'iceh.1992-04-14.nc', 'iceh.1992-04-15.nc', 'iceh.1992-04-16.nc', 'iceh.1992-04-17.nc', 'iceh.1992-04-18.nc', 'iceh.1992-04-19.nc', 'iceh.1992-04-20.nc', 'iceh.1992-04-21.nc', 'iceh.1992-04-22.nc', 'iceh.1992-04-23.nc', 'iceh.1992-04-24.nc', 'iceh.1992-04-25.nc', 'iceh.1992-04-26.nc', 'iceh.1992-04-27.nc', 'iceh.1992-04-28.nc', 'iceh.1992-04-29.nc', 'iceh.1992-04-30.nc', 'iceh_d.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-05-01.nc', 'iceh.1992-05-02.nc', 'iceh.1992-05-03.nc', 'iceh.1992-05-04.nc', 'iceh.1992-05-05.nc', 'iceh.1992-05-06.nc', 'iceh.1992-05-07.nc', 'iceh.1992-05-08.nc', 'iceh.1992-05-09.nc', 'iceh.1992-05-10.nc', 'iceh.1992-05-11.nc', 'iceh.1992-05-12.nc', 'iceh.1992-05-13.nc', 'iceh.1992-05-14.nc', 'iceh.1992-05-15.nc', 'iceh.1992-05-16.nc', 'iceh.1992-05-17.nc', 'iceh.1992-05-18.nc', 'iceh.1992-05-19.nc', 'iceh.1992-05-20.nc', 'iceh.1992-05-21.nc', 'iceh.1992-05-22.nc', 'iceh.1992-05-23.nc', 'iceh.1992-05-24.nc', 'iceh.1992-05-25.nc', 'iceh.1992-05-26.nc', 'iceh.1992-05-27.nc', 'iceh.1992-05-28.nc', 'iceh.1992-05-29.nc', 'iceh.1992-05-30.nc', 'iceh.1992-05-31.nc', 'iceh_d.1992-05.nc']
```
The "new" version throws warnings but then completes the same commands as it would have done for the `both` folder:
```
$ diff <(./ice_nc4_new.py both_unexpected) <(./ice_nc4_new.py both)

./ice_nc4_new.py:33: UserWarning: Unexpected file 'iceh.1992.04.05.nc'.
  warnings.warn(f"Unexpected file '{f}'.")
./ice_nc4_new.py:33: UserWarning: Unexpected file 'iceh.unexpected.nc'.
  warnings.warn(f"Unexpected file '{f}'.")
```
This is good, because if there are still all the files properly formatted for the processing, there is no need to fail.

#### both_missing
##### "old" version
```
$ ./ice_nc4_old.py both_missing
['nccopy', '-k3', '-d4', 'iceh.1992-04.nc', 'iceh_m.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-04-01.nc', 'iceh.1992-04-02.nc', 'iceh.1992-04-03.nc', 'iceh.1992-04-04.nc', 'iceh.1992-04-05.nc', 'iceh.1992-04-06.nc', 'iceh.1992-04-07.nc', 'iceh.1992-04-08.nc', 'iceh.1992-04-09.nc', 'iceh.1992-04-10.nc', 'iceh.1992-04-11.nc', 'iceh.1992-04-12.nc', 'iceh.1992-04-13.nc', 'iceh.1992-04-14.nc', 'iceh.1992-04-15.nc', 'iceh.1992-04-16.nc', 'iceh.1992-04-17.nc', 'iceh.1992-04-18.nc', 'iceh.1992-04-19.nc', 'iceh.1992-04-20.nc', 'iceh.1992-04-21.nc', 'iceh.1992-04-22.nc', 'iceh.1992-04-23.nc', 'iceh.1992-04-24.nc', 'iceh.1992-04-25.nc', 'iceh.1992-04-26.nc', 'iceh.1992-04-27.nc', 'iceh.1992-04-28.nc', 'iceh.1992-04-29.nc', 'iceh.1992-04-30.nc', 'iceh_d.1992-04.nc']
['nccopy', '-k3', '-d4', 'iceh.1992-05.nc', 'iceh_m.1992-05.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-05-01.nc', 'iceh.1992-05-02.nc', 'iceh.1992-05-03.nc', 'iceh.1992-05-04.nc', 'iceh.1992-05-05.nc', 'iceh.1992-05-06.nc', 'iceh.1992-05-07.nc', 'iceh.1992-05-08.nc', 'iceh.1992-05-09.nc', 'iceh.1992-05-10.nc', 'iceh.1992-05-11.nc', 'iceh.1992-05-12.nc', 'iceh.1992-05-13.nc', 'iceh.1992-05-14.nc', 'iceh.1992-05-15.nc', 'iceh.1992-05-16.nc', 'iceh.1992-05-17.nc', 'iceh.1992-05-18.nc', 'iceh.1992-05-19.nc', 'iceh.1992-05-20.nc', 'iceh.1992-05-21.nc', 'iceh.1992-05-22.nc', 'iceh.1992-05-23.nc', 'iceh.1992-05-24.nc', 'iceh.1992-05-25.nc', 'iceh.1992-05-26.nc', 'iceh.1992-05-27.nc', 'iceh.1992-05-28.nc', 'iceh.1992-05-29.nc', 'iceh.1992-05-30.nc', 'iceh.1992-05-31.nc', 'iceh_d.1992-05.nc']
```
The "old" version runs wrong commands, that fail: the second `ncrcat` command includes the `iceh.1992-05-04.nc` file that is missing in the `both_missing` directory (therefore the command would fail).

##### "new" version
```
$ ./ice_nc4_new.py both_missing
['nccopy', '-k3', '-d4', 'iceh.1992-05.nc', 'iceh_m.1992-05.nc']
['nccopy', '-k3', '-d4', 'iceh.1992-04.nc', 'iceh_m.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-04-01.nc', 'iceh.1992-04-02.nc', 'iceh.1992-04-03.nc', 'iceh.1992-04-04.nc', 'iceh.1992-04-05.nc', 'iceh.1992-04-06.nc', 'iceh.1992-04-07.nc', 'iceh.1992-04-08.nc', 'iceh.1992-04-09.nc', 'iceh.1992-04-10.nc', 'iceh.1992-04-11.nc', 'iceh.1992-04-12.nc', 'iceh.1992-04-13.nc', 'iceh.1992-04-14.nc', 'iceh.1992-04-15.nc', 'iceh.1992-04-16.nc', 'iceh.1992-04-17.nc', 'iceh.1992-04-18.nc', 'iceh.1992-04-19.nc', 'iceh.1992-04-20.nc', 'iceh.1992-04-21.nc', 'iceh.1992-04-22.nc', 'iceh.1992-04-23.nc', 'iceh.1992-04-24.nc', 'iceh.1992-04-25.nc', 'iceh.1992-04-26.nc', 'iceh.1992-04-27.nc', 'iceh.1992-04-28.nc', 'iceh.1992-04-29.nc', 'iceh.1992-04-30.nc', 'iceh_d.1992-04.nc']
Traceback (most recent call last):
  File "./ice_nc4_new.py", line 66, in <module>
    raise Exception(f"Missing daily data 'iceh.{year}-{month}-{day:02d}.nc'.")
Exception: Missing daily data 'iceh.1992-05-04.nc'.
```
The "new" version, instead, throws an exception.

#### only_monthly
##### "old" version
```
$ ./ice_nc4_old.py only_monthly
['nccopy', '-k3', '-d4', 'iceh.1992-04.nc', 'iceh_m.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-04-01.nc', 'iceh.1992-04-02.nc', 'iceh.1992-04-03.nc', 'iceh.1992-04-04.nc', 'iceh.1992-04-05.nc', 'iceh.1992-04-06.nc', 'iceh.1992-04-07.nc', 'iceh.1992-04-08.nc', 'iceh.1992-04-09.nc', 'iceh.1992-04-10.nc', 'iceh.1992-04-11.nc', 'iceh.1992-04-12.nc', 'iceh.1992-04-13.nc', 'iceh.1992-04-14.nc', 'iceh.1992-04-15.nc', 'iceh.1992-04-16.nc', 'iceh.1992-04-17.nc', 'iceh.1992-04-18.nc', 'iceh.1992-04-19.nc', 'iceh.1992-04-20.nc', 'iceh.1992-04-21.nc', 'iceh.1992-04-22.nc', 'iceh.1992-04-23.nc', 'iceh.1992-04-24.nc', 'iceh.1992-04-25.nc', 'iceh.1992-04-26.nc', 'iceh.1992-04-27.nc', 'iceh.1992-04-28.nc', 'iceh.1992-04-29.nc', 'iceh.1992-04-30.nc', 'iceh_d.1992-04.nc']
['nccopy', '-k3', '-d4', 'iceh.1992-05.nc', 'iceh_m.1992-05.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-05-01.nc', 'iceh.1992-05-02.nc', 'iceh.1992-05-03.nc', 'iceh.1992-05-04.nc', 'iceh.1992-05-05.nc', 'iceh.1992-05-06.nc', 'iceh.1992-05-07.nc', 'iceh.1992-05-08.nc', 'iceh.1992-05-09.nc', 'iceh.1992-05-10.nc', 'iceh.1992-05-11.nc', 'iceh.1992-05-12.nc', 'iceh.1992-05-13.nc', 'iceh.1992-05-14.nc', 'iceh.1992-05-15.nc', 'iceh.1992-05-16.nc', 'iceh.1992-05-17.nc', 'iceh.1992-05-18.nc', 'iceh.1992-05-19.nc', 'iceh.1992-05-20.nc', 'iceh.1992-05-21.nc', 'iceh.1992-05-22.nc', 'iceh.1992-05-23.nc', 'iceh.1992-05-24.nc', 'iceh.1992-05-25.nc', 'iceh.1992-05-26.nc', 'iceh.1992-05-27.nc', 'iceh.1992-05-28.nc', 'iceh.1992-05-29.nc', 'iceh.1992-05-30.nc', 'iceh.1992-05-31.nc', 'iceh_d.1992-05.nc']
```
The "old" version runs wrong commands, that fail: the `ncrcat` commands include daily data that is missing in the `only_monthly` directory (therefore the commands would fail).

##### "new" version
```
$ ./ice_nc4_new.py only_monthly
['nccopy', '-k3', '-d4', 'iceh.1992-05.nc', 'iceh_m.1992-05.nc']
['nccopy', '-k3', '-d4', 'iceh.1992-04.nc', 'iceh_m.1992-04.nc']
No daily data to process.
```
The "new" version only processes the monthly data.

#### only_daily
##### "old" version
```
$ ./ice_nc4_old.py only_daily
No files to process
```
The "old" version does not process any data when, instead, the daily data should be processed.

##### "new" version
```
$ ./ice_nc4_new.py only_daily
No monthly data to process.
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-04-01.nc', 'iceh.1992-04-02.nc', 'iceh.1992-04-03.nc', 'iceh.1992-04-04.nc', 'iceh.1992-04-05.nc', 'iceh.1992-04-06.nc', 'iceh.1992-04-07.nc', 'iceh.1992-04-08.nc', 'iceh.1992-04-09.nc', 'iceh.1992-04-10.nc', 'iceh.1992-04-11.nc', 'iceh.1992-04-12.nc', 'iceh.1992-04-13.nc', 'iceh.1992-04-14.nc', 'iceh.1992-04-15.nc', 'iceh.1992-04-16.nc', 'iceh.1992-04-17.nc', 'iceh.1992-04-18.nc', 'iceh.1992-04-19.nc', 'iceh.1992-04-20.nc', 'iceh.1992-04-21.nc', 'iceh.1992-04-22.nc', 'iceh.1992-04-23.nc', 'iceh.1992-04-24.nc', 'iceh.1992-04-25.nc', 'iceh.1992-04-26.nc', 'iceh.1992-04-27.nc', 'iceh.1992-04-28.nc', 'iceh.1992-04-29.nc', 'iceh.1992-04-30.nc', 'iceh_d.1992-04.nc']
['ncrcat', '-4', '--deflate', '4', 'iceh.1992-05-01.nc', 'iceh.1992-05-02.nc', 'iceh.1992-05-03.nc', 'iceh.1992-05-04.nc', 'iceh.1992-05-05.nc', 'iceh.1992-05-06.nc', 'iceh.1992-05-07.nc', 'iceh.1992-05-08.nc', 'iceh.1992-05-09.nc', 'iceh.1992-05-10.nc', 'iceh.1992-05-11.nc', 'iceh.1992-05-12.nc', 'iceh.1992-05-13.nc', 'iceh.1992-05-14.nc', 'iceh.1992-05-15.nc', 'iceh.1992-05-16.nc', 'iceh.1992-05-17.nc', 'iceh.1992-05-18.nc', 'iceh.1992-05-19.nc', 'iceh.1992-05-20.nc', 'iceh.1992-05-21.nc', 'iceh.1992-05-22.nc', 'iceh.1992-05-23.nc', 'iceh.1992-05-24.nc', 'iceh.1992-05-25.nc', 'iceh.1992-05-26.nc', 'iceh.1992-05-27.nc', 'iceh.1992-05-28.nc', 'iceh.1992-05-29.nc', 'iceh.1992-05-30.nc', 'iceh.1992-05-31.nc', 'iceh_d.1992-05.nc']
```
The "new" version correctly processes daily data.





 

